### PR TITLE
Add missing dependency to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get install -y \
     libogg-dev \
     libini-config-dev \
     libcollection-dev \
+    libconfig-dev \
     pkg-config \
     gengetopt \
     libtool \

--- a/conf/janus.plugin.streaming.cfg
+++ b/conf/janus.plugin.streaming.cfg
@@ -64,25 +64,19 @@ video = yes
 videoport = 10001
 videopt = 126
 videortpmap = H264/90000
-videofmtp = packetization-mode=1
+videofmtp = profile-level-id=42e01f\;packetization-mode=1
 
-[file-live-sample]
-type = live
+
+[rtsp-test]
+type = rtsp
 id = 2
-description = a-law file source (radio broadcast)
-filename = /opt/janus/share/janus/streams/radio.alaw		; See install.sh
-audio = yes
-video = no
-secret = adminpwd
-
-[file-ondemand-sample]
-type = ondemand
-id = 3
-description = mu-law file source (music)
-filename = /opt/janus/share/janus/streams/music.mulaw	; See install.sh
-audio = yes
-video = no
-secret = adminpwd
+description = RTSP Test
+audio = no
+video = yes
+url= rtsp://10.110.0.215:554/StreamingSetting?version=1.0&action=getRTSPStream&ChannelID=3&ChannelName=Channel3
+rtsp_user=video
+rtsp_pwd=BSC.video
+videofmtp = profile-level-id=42e01f\;packetization-mode=1
 
 ;
 ; Firefox Nightly supports H.264 through Cisco's OpenH264 plugin. The only

--- a/conf/janus.plugin.streaming.cfg
+++ b/conf/janus.plugin.streaming.cfg
@@ -1,0 +1,139 @@
+; [stream-name]
+; type = rtp
+; id = <unique numeric ID> (if missing, a random one will be generated)
+; description = This is my awesome stream
+; is_private = yes|no (private streams don't appear when you do a 'list'
+;			request)
+; secret = <optional password needed for manipulating (e.g., destroying
+;			or enabling/disabling) the stream>
+; pin = <optional password needed for watching the stream>
+; filename = path to the local file to stream (only for live/ondemand)
+; audio = yes|no (do/don't stream audio)
+; video = yes|no (do/don't stream video)
+;    The following options are only valid for the 'rtp' type:
+; data = yes|no (do/don't stream text via datachannels)
+; audioport = local port for receiving audio frames
+; audiomcast = multicast group port for receiving audio frames, if any
+; audioiface = network interface or IP address to bind to, if any (binds to all otherwise)
+; audiopt = <audio RTP payload type> (e.g., 111)
+; audiortpmap = RTP map of the audio codec (e.g., opus/48000/2)
+; videoport = local port for receiving video frames
+; videomcast = multicast group port for receiving video frames, if any
+; videoiface = network interface or IP address to bind to, if any (binds to all otherwise)
+; videopt = <video RTP payload type> (e.g., 100)
+; videortpmap = RTP map of the video codec (e.g., VP8/90000)
+; videobufferkf = yes|no (whether the plugin should store the latest
+;		keyframe and send it immediately for new viewers, EXPERIMENTAL)
+; videosimulcast = yes|no (do|don't enable video simulcasting)
+; videoport2 = second local port for receiving video frames (only for rtp, and simulcasting)
+; videoport3 = third local port for receiving video frames (only for rtp, and simulcasting)
+; dataport = local port for receiving data messages to relay
+; dataiface = network interface or IP address to bind to, if any (binds to all otherwise)
+; databuffermsg = yes|no (whether the plugin should store the latest
+;		message and send it immediately for new viewers)
+;
+; The following options are only valid for the 'rstp' type:
+; url = RTSP stream URL (only for restreaming RTSP)
+; rtsp_user = RTSP authorization username (only if type=rtsp)
+; rtsp_pwd = RTSP authorization password (only if type=rtsp)
+; rtspiface = network interface or IP address to bind to, if any (binds to all otherwise), when receiving RTSP streams
+;
+; Notice that, for 'rtsp' mountpoints, normally the plugin uses the exact
+; SDP rtpmap and fmtp attributes the remote camera or RTSP server sent.
+; In case the values set remotely are known to conflict with WebRTC viewers,
+; you can override both using the settings introduced above.
+;
+; To test the [gstreamer-sample] example, check the test_gstreamer.sh
+; script in the plugins/streams folder. To test the live and on-demand
+; audio file streams, instead, the install.sh installation script
+; automatically downloads a couple of files (radio.alaw, music.mulaw)
+; to the plugins/streams folder. 
+
+[general]
+;admin_key = supersecret		; If set, mountpoints can be created via API
+								; only if this key is provided in the request
+;events = no					; Whether events should be sent to event
+								; handlers (default is yes)
+
+[gstreamer-sample]
+type = rtp
+id = 1
+description = Opus/VP8 live stream coming from gstreamer
+audio = no
+video = yes
+videoport = 10001
+videopt = 126
+videortpmap = H264/90000
+videofmtp = packetization-mode=1
+
+[file-live-sample]
+type = live
+id = 2
+description = a-law file source (radio broadcast)
+filename = /opt/janus/share/janus/streams/radio.alaw		; See install.sh
+audio = yes
+video = no
+secret = adminpwd
+
+[file-ondemand-sample]
+type = ondemand
+id = 3
+description = mu-law file source (music)
+filename = /opt/janus/share/janus/streams/music.mulaw	; See install.sh
+audio = yes
+video = no
+secret = adminpwd
+
+;
+; Firefox Nightly supports H.264 through Cisco's OpenH264 plugin. The only
+; supported profile is the baseline one. This is an example of how to create
+; a H.264 mountpoint: you can feed it an x264enc+rtph264pay pipeline in
+; gstreamer.
+;
+;[h264-sample]
+;type = rtp
+;id = 10
+;description = H.264 live stream coming from gstreamer
+;audio = no
+;video = yes
+;videoport = 8004
+;videopt = 126
+;videortpmap = H264/90000
+;videofmtp = profile-level-id=42e01f\;packetization-mode=1
+
+;
+; This is a sample configuration for Opus/VP8 multicast streams
+;
+;[gstreamer-multicast]
+;type = rtp
+;id = 20
+;description = Opus/VP8 live multicast stream coming from gstreamer 
+;audio = yes
+;video = yes
+;audioport = 5002
+;audiomcast = 232.3.4.5
+;audiopt = 111
+;audiortpmap = opus/48000/2
+;videoport = 5004
+;videomcast = 232.3.4.5
+;videopt = 100
+;videortpmap = VP8/90000
+
+;
+; This is a sample configuration for an RTSP stream: you can specify
+; the url to connect to and whether or not authentication is needed
+; using the url/rtsp_user/rtsp_pwd settings (but notice that digest
+; authentication will only work if you installed libcurl >= 7.45.0)
+; NOTE WELL: the plugin does NOT transcode, so the RTSP stream MUST be
+; in a format the browser can digest (e.g., VP8 or H.264 baseline for video)
+; Again, you can override rtpmap and/or fmtp, if needed
+;
+;[rtsp-test]
+;type = rtsp
+;id = 99
+;description = RTSP Test
+;audio = no
+;video = yes
+;url=rtsp://127.0.0.1:8554/unicast
+;rtsp_user=username
+;rtsp_pwd=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,13 @@ version: '2'
 
 services:
   janus-gateway:
-    image: linagora/docker-janus-gateway
+    image: registry:5000/nbycomp/services/ebv/janus:1.0.0
+    build:
+      context: .
+    volumes:
+      - ./conf:/opt/janus/etc/janus/
     ports:
+      - "8888:8888"
       - "80:80"
       - "7088:7088"
       - "8088:8088"
@@ -12,3 +17,9 @@ services:
       - "10000-10200:10000-10200/udp"
     environment:
       - DOCKER_IP=${DOCKER_IP}
+      - FEED1_LABEL=${FEED1_LABEL}
+      - FEED2_LABEL=${FEED2_LABEL}
+      - FEED2_USER=${FEED2_USER}
+      - FEED2_PASSWORD=${FEED2_PASSWORD}
+      - FEED2_URL=${FEED2_URL}
+      

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+rtp_stream () {
+    cat <<EOF
+[rtp]
+type = rtp
+id = $1
+description = feed $1
+audio = no
+video = yes
+videoport = $2
+videopt = 126
+videortpmap = H264/90000
+videofmtp = profile-level-id=42e01f\;packetization-mode=1
+EOF
+}
+
+rtsp_stream () {
+    cat <<EOF
+[rtsp]
+type = rtsp
+id = $i
+description = cellnex 2
+audio = no
+video = yes
+url=
+rtsp_user=
+rtsp_pwd=
+videofmtp = profile-level-id=42e01f\;packetization-mode=1
+EOF
+}
+
+case $FEED_COUNT in
+    ''|*[!0-9]*)
+        echo "expected \$FEED_COUNT to be an integer, got: $FEED_COUNT" >&2
+        exit 1
+        ;;
+    *)
+        port_range_start=10001
+        port_range_end=$(( 10000 + FEED_COUNT ))
+        echo "creating $FEED_COUNT RTP streams listening on ports $port_range_start-$port_range_end"
+        ;;
+esac
+
+id=1
+while { port=$(( port_range_start + id - 1 )); [ $port -le $port_range_end ]; } do
+    rtp_stream $id $port
+    id=$(( id + 1 ))
+done > /opt/janus/etc/janus/janus.plugin.streaming.cfg
+
+service nginx restart && /opt/janus/bin/janus --nat-1-1=${DOCKER_IP}


### PR DESCRIPTION
The latest version of janus-gateway [requires libconfig](https://github.com/meetecho/janus-gateway#dependencies).