### PR TITLE
Dependencies updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:buster
 
 LABEL maintainer="Linagora Folks <lgs-openpaas-dev@linagora.com>"
 LABEL description="Provides an image with Janus Gateway"
@@ -15,11 +15,13 @@ RUN apt-get install -y \
     libsofia-sip-ua-dev \
     libglib2.0-dev \
     libopus-dev \
+    libconfig-dev \
     libogg-dev \
     libini-config-dev \
     libcollection-dev \
     pkg-config \
     gengetopt \
+    libcurl4-openssl-dev \
     libtool \
     autotools-dev \
     automake
@@ -35,7 +37,6 @@ RUN apt-get install -y \
 RUN cd ~ \
     && git clone https://github.com/cisco/libsrtp.git \
     && cd libsrtp \
-    && git checkout v2.0.0 \
     && ./configure --prefix=/usr --enable-openssl \
     && make shared_library \
     && sudo make install
@@ -62,12 +63,12 @@ RUN cd ~ \
     && git clone https://github.com/meetecho/janus-gateway.git \
     && cd janus-gateway \
     && sh autogen.sh \
-    && ./configure --prefix=/opt/janus --disable-rabbitmq --disable-mqtt --enable-docs \
+    && ./configure --prefix=/opt/janus --disable-rabbitmq --disable-mqtt \
     && make CFLAGS='-std=c99' \
     && make install \
     && make configs
 
-RUN cp -rp ~/janus-gateway/certs /opt/janus/share/janus
+#RUN cp -rp ~/janus-gateway/certs /opt/janus/share/janus
 
 COPY conf/*.cfg /opt/janus/etc/janus/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Linagora Folks <lgs-openpaas-dev@linagora.com>"
 LABEL description="Provides an image with Janus Gateway"
 
 ENV DEBIAN_FRONTEND "noninteractive"
-RUN ln -fs /usr/share/zoneinfo/Europe/Rome /etc/localtime
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN apt-get update -y \
     && apt-get upgrade -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM debian:buster
+FROM ubuntu:focal
 
 LABEL maintainer="Linagora Folks <lgs-openpaas-dev@linagora.com>"
 LABEL description="Provides an image with Janus Gateway"
 
+ENV DEBIAN_FRONTEND "noninteractive"
+RUN ln -fs /usr/share/zoneinfo/Europe/Rome /etc/localtime
 RUN apt-get update -y \
     && apt-get upgrade -y
 
@@ -63,7 +65,7 @@ RUN cd ~ \
     && git clone https://github.com/meetecho/janus-gateway.git \
     && cd janus-gateway \
     && sh autogen.sh \
-    && ./configure --prefix=/opt/janus --disable-rabbitmq --disable-mqtt \
+    && ./configure --prefix=/opt/janus --disable-rabbitmq --disable-mqtt --enable-docs \
     && make CFLAGS='-std=c99' \
     && make install \
     && make configs


### PR DESCRIPTION
Hi,
We solved #5 and moved base image to `ubuntu:focal`.
Janus wok well but documentation are not shown though is enabled.